### PR TITLE
Fixed /scim/v2/User/# endpoint to return 404 instead of 500

### DIFF
--- a/src/coldfront_plugin_api/scim_v2/users.py
+++ b/src/coldfront_plugin_api/scim_v2/users.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import User
+from django.http import Http404
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
@@ -108,5 +109,8 @@ class UserDetail(APIView):
     permission_classes = [IsAdminUser]
 
     def get(self, request, username, format=None):
-        allocation = User.objects.get(username=username)
+        try:
+            allocation = User.objects.get(username=username)
+        except User.DoesNotExist:
+            return Response(status=404)
         return Response(user_to_api_representation(allocation))


### PR DESCRIPTION
Fixes https://github.com/nerc-project/coldfront-plugin-api/issues/15 by performing a try-except block around the query call.

The last PR was closed because while trying to reset and rebasing and squashing, I accidentally pushed such that the main branch and my local branch was identical, thus automatically closing the PR?